### PR TITLE
Fixing debug prop not falling through

### DIFF
--- a/src/components/VueScrollama.vue
+++ b/src/components/VueScrollama.vue
@@ -41,13 +41,7 @@ const emit = defineEmits();
 
 let rootElement = ref(null);
 const _scroller = ref(null);
-const attrs = new Proxy(
-  {},
-  {
-    get: (_, prop) => rootElement.value.getAttribute(prop),
-    has: (_, prop) => rootElement.value.hasAttribute(prop),
-  }
-);
+const attrs = useAttrs();
 
 onMounted(() => {
   _scroller.value = scrollama();
@@ -73,9 +67,8 @@ function setup() {
   if (rootElement.value) {
     const opts = {
       step: Array.from(rootElement.value.children),
-      progress: "step-progress" in attrs,
-      debug: props.debug,
-      ...attrs,
+      progress: props.progress ?? "onStepProgress" in attrs,
+      ...props,
     };
 
     _scroller.value = scrollama()

--- a/src/components/VueScrollama.vue
+++ b/src/components/VueScrollama.vue
@@ -74,6 +74,7 @@ function setup() {
     const opts = {
       step: Array.from(rootElement.value.children),
       progress: "step-progress" in attrs,
+      debug: props.debug,
       ...attrs,
     };
 


### PR DESCRIPTION
:bug: Related to the [issue about the debugging interface](https://github.com/devarteneur/vue3-scrollama/issues/1).

Since your [last commit,](https://github.com/devarteneur/vue3-scrollama/commit/00810c89edd4623061bf31373935bc26342809d7) `debug` is now defined in the `props` of the component.
Because of that, it's not part of the `attrs` anymore.

As you can find in [the documentation](https://vuejs.org/guide/components/attrs.html#attribute-inheritance):

> A "fallthrough attribute" is an attribute or v-on event listener that is passed to a component, but is **not explicitly declared in the receiving component's [props](https://vuejs.org/guide/components/props)** or [emits](https://vuejs.org/guide/components/events#declaring-emitted-events).

This PR is a quick fix, where we get debug from the props directly and pass it to the Scrollama setup options.